### PR TITLE
fix: dereference *string in fmt.Errorf for HaChassisGroup

### DIFF
--- a/internal/ovnrouter/ovnrouter.go
+++ b/internal/ovnrouter/ovnrouter.go
@@ -192,6 +192,10 @@ func (m *Manager) Failover(ctx context.Context, router *apiv1alpha1.Router) erro
 		}
 	}
 
+	if gatewayPortInfo == nil {
+		return fmt.Errorf("no gateway chassis found for router %q", router.UID)
+	}
+
 	lrp := nbdb.LogicalRouterPort{UUID: string(*gatewayPortInfo.InternalUUID)}
 	if err := m.client.Get(ctx, &lrp); err != nil {
 		return fmt.Errorf("failed to get logical router port %q for router %q: %w", gatewayPortInfo.UUID, router.UID, err)
@@ -203,7 +207,7 @@ func (m *Manager) Failover(ctx context.Context, router *apiv1alpha1.Router) erro
 	if lrp.HaChassisGroup != nil {
 		haChassisGroup := nbdb.HAChassisGroup{UUID: *lrp.HaChassisGroup}
 		if err := m.client.Get(ctx, &haChassisGroup); err != nil {
-			return fmt.Errorf("failed to get HA chassis group %q for logical router port %q: %w", lrp.HaChassisGroup, lrp.UUID, err)
+			return fmt.Errorf("failed to get HA chassis group %q for logical router port %q: %w", *lrp.HaChassisGroup, lrp.UUID, err)
 		}
 
 		haChassis := []nbdb.HAChassis{}


### PR DESCRIPTION
## Problem

CI has been failing since commit 162d467b (Sep 16, 2025) due to a `govet` error:

```
fmt.Errorf format %q has arg lrp.HaChassisGroup of wrong type *string
```

Both `golangci-lint` and `go-test` jobs fail because of this. This also causes StepSecurity PR #35 to fail.

## Fix

Dereference `lrp.HaChassisGroup` to `*lrp.HaChassisGroup` in the `fmt.Errorf` call at line 206, since the nil check is already done on line 203.